### PR TITLE
Support camelCase keys

### DIFF
--- a/lib/flutter_translate_gen.dart
+++ b/lib/flutter_translate_gen.dart
@@ -82,6 +82,7 @@ class FlutterTranslateGen extends AnnotationGenerator<TranslateKeysOptions>
     {
         switch(options.caseStyle)
         {
+            case CaseStyle.camelCase: return Casing.camelCase(key);
             case CaseStyle.titleCase: return Casing.titleCase(key,separator: options.separator);
             case CaseStyle.upperCase: return Casing.upperCase(key,separator: options.separator);
             case CaseStyle.lowerCase: return Casing.lowerCase(key,separator: options.separator);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,10 +16,7 @@ dependencies:
   dart_casing: ^1.0.1
   dart_style: ^2.0.0
   dart_utils: ^1.0.2
-  flutter_translate_annotations:
-    git:
-      url: https://github.com/seasox/flutter_translate_annotations
-      ref: camel_case_keys
+  flutter_translate_annotations: ^2.0.0
   glob: ^2.0.1
   source_gen: ^1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,7 @@ description: Statically-typed localization keys generator for flutter_translate.
 version: 2.0.0
 homepage: https://leadcode.dev
 repository: https://github.com/bratan/flutter_translate_gen
+publish_to: none
 
 environment:
   sdk: ">=2.5.0 <3.0.0"
@@ -15,7 +16,10 @@ dependencies:
   dart_casing: ^1.0.1
   dart_style: ^2.0.0
   dart_utils: ^1.0.2
-  flutter_translate_annotations: ^2.0.0
+  flutter_translate_annotations:
+    git:
+      url: https://github.com/seasox/flutter_translate_annotations
+      ref: camel_case_keys
   glob: ^2.0.1
   source_gen: ^1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,6 @@ description: Statically-typed localization keys generator for flutter_translate.
 version: 2.0.0
 homepage: https://leadcode.dev
 repository: https://github.com/bratan/flutter_translate_gen
-publish_to: none
 
 environment:
   sdk: ">=2.5.0 <3.0.0"
@@ -16,10 +15,7 @@ dependencies:
   dart_casing: ^1.0.1
   dart_style: ^2.0.0
   dart_utils: ^1.0.2
-  flutter_translate_annotations:
-    git:
-      url: https://github.com/seasox/flutter_translate_annotations
-      ref: camel_case_keys
+  flutter_translate_annotations: ^2.0.0
   glob: ^2.0.1
   source_gen: ^1.0.0
 


### PR DESCRIPTION
As requested per #4, this PR implements camelCase key support. See also https://github.com/bratan/flutter_translate_annotations/pull/3