### PR TITLE
feat: upgrade dependencies for analyzer >=2.7.0 <4.0.0 compatibilty

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,16 +8,16 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^1.7.2
+  analyzer: ">=2.7.0 <4.0.0"
   async: ^2.8.2
   build: ^2.1.1
   code_builder: ^4.1.0
   dart_casing: ^2.0.0
-  dart_style: ^2.0.0
+  dart_style: ^2.2.0
   dart_utils: ^2.0.0
   flutter_translate_annotations: ^2.1.0
   glob: ^2.0.2
-  source_gen: ^1.0.0
+  source_gen: ^1.1.1
 
 dev_dependencies:
   build_runner: ^2.1.5


### PR DESCRIPTION
Hello, I had some conflict dependency issues when I used the latest versions of flutter_gen_runner, auto_route_generator and json_serializable, even it could have more because of the analyzer version is lower than other dependencies. This is how I could fix the dependencies version confict between these packages